### PR TITLE
feat: 管理画面にStorage集計機能を追加

### DIFF
--- a/src/lib/api/exports.js
+++ b/src/lib/api/exports.js
@@ -1,0 +1,77 @@
+/**
+ * エクスポート関連のAPI呼び出しを管理するモジュール
+ */
+
+/**
+ * ファイルの存在確認
+ * @param {string} organizationId
+ * @param {number} year
+ * @param {string} basePath - $app/paths の base
+ * @returns {Promise<{exists: boolean}>}
+ */
+export async function checkExportStatus(organizationId, year, basePath) {
+  const response = await fetch(
+    `${basePath}/api/organizations/${organizationId}/export-status?year=${year}`,
+    { method: 'GET' }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Status check failed: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * 集計処理を実行
+ * @param {string} organizationId
+ * @param {number} year
+ * @param {string} basePath - $app/paths の base
+ * @returns {Promise<{signedUrl: string}>}
+ */
+export async function aggregateExport(organizationId, year, basePath) {
+  const response = await fetch(
+    `${basePath}/api/organizations/${organizationId}/export-cards?year=${year}`,
+    { method: 'POST' }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Aggregate failed: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * ダウンロード用の署名付きURLを取得
+ * @param {string} organizationId
+ * @param {number} year
+ * @param {string} basePath - $app/paths の base
+ * @returns {Promise<{signedUrl: string}>}
+ */
+export async function getExportSignedUrl(organizationId, year, basePath) {
+  const response = await fetch(
+    `${basePath}/api/organizations/${organizationId}/export-get-signed-url?year=${year}`,
+    { method: 'GET' }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to get signed URL: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * 署名付きURLを使ってファイルをダウンロード
+ * @param {string} signedUrl
+ * @param {string} filename
+ */
+export function downloadFile(signedUrl, filename) {
+  const link = document.createElement('a');
+  link.href = signedUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}

--- a/src/routes/[organizationId]/admin/+page.svelte
+++ b/src/routes/[organizationId]/admin/+page.svelte
@@ -29,7 +29,10 @@
   let checkingStatus = false;
 
   /** @type {boolean} */
-  let exporting = false;
+  let aggregating = false;
+
+  /** @type {boolean} */
+  let downloading = false;
 
   /** @type {boolean} */
   let isAdmin = false;
@@ -84,8 +87,8 @@
   };
 
   const handleAggregate = async () => {
-    if (exporting) return;
-    exporting = true;
+    if (aggregating) return;
+    aggregating = true;
 
     try {
       await aggregateExport($page.params.organizationId, exportYear, base);
@@ -95,13 +98,13 @@
       console.error('Aggregate error:', error);
       alert('集計に失敗しました');
     } finally {
-      exporting = false;
+      aggregating = false;
     }
   };
 
   const handleDownload = async () => {
-    if (exporting || !fileExists) return;
-    exporting = true;
+    if (downloading || !fileExists) return;
+    downloading = true;
 
     try {
       const result = await getExportSignedUrl($page.params.organizationId, exportYear, base);
@@ -115,7 +118,7 @@
       console.error('Download error:', error);
       alert('ダウンロードに失敗しました');
     } finally {
-      exporting = false;
+      downloading = false;
     }
   };
 
@@ -140,18 +143,18 @@
         id="export-year"
         bind:value={exportYear}
         on:change={handleYearChange}
-        disabled={exporting || checkingStatus}
+        disabled={aggregating || checkingStatus}
       >
         {#each Array.from({ length: new Date().getFullYear() - 2023 }, (_, i) => 2024 + i) as year}
           <option value={year}>{year}</option>
         {/each}
       </select>
       <label for="export-year">年</label>
-      <FloatButton on:click={handleAggregate} disabled={exporting}>
-        {exporting ? '集計中...' : '集計'}
+      <FloatButton on:click={handleAggregate} disabled={aggregating}>
+        {aggregating ? '集計中...' : '集計'}
       </FloatButton>
-      <FloatButton on:click={handleDownload} disabled={exporting || !fileExists}>
-        {exporting ? 'ダウンロード中...' : fileExists ? 'ダウンロード' : 'ファイルなし'}
+      <FloatButton on:click={handleDownload} disabled={downloading || !fileExists}>
+        {downloading ? 'ダウンロード中...' : fileExists ? 'ダウンロード' : 'ファイルなし'}
       </FloatButton>
     </div>
   </div>

--- a/src/routes/[organizationId]/admin/+page.svelte
+++ b/src/routes/[organizationId]/admin/+page.svelte
@@ -167,7 +167,12 @@
   <div class="export-section">
     <h2>カード情報をエクスポート</h2>
     <div class="export-controls">
-      <select id="export-year" bind:value={exportYear} on:change={handleYearChange} disabled={exporting || checkingStatus}>
+      <select
+        id="export-year"
+        bind:value={exportYear}
+        on:change={handleYearChange}
+        disabled={exporting || checkingStatus}
+      >
         {#each Array.from({ length: new Date().getFullYear() - 2023 }, (_, i) => 2024 + i) as year}
           <option value={year}>{year}</option>
         {/each}

--- a/src/routes/[organizationId]/admin/+page.svelte
+++ b/src/routes/[organizationId]/admin/+page.svelte
@@ -4,7 +4,12 @@
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import FloatButton from '$lib/components/design/FloatButton.svelte';
-  import { checkExportStatus, aggregateExport, getExportSignedUrl, downloadFile } from '$lib/api/exports.js';
+  import {
+    checkExportStatus,
+    aggregateExport,
+    getExportSignedUrl,
+    downloadFile,
+  } from '$lib/api/exports.js';
   import { onMount } from 'svelte';
 
   watchMemberCollection($page.params.organizationId);

--- a/src/routes/api/organizations/[organizationId]/export-get-signed-url/+server.js
+++ b/src/routes/api/organizations/[organizationId]/export-get-signed-url/+server.js
@@ -1,0 +1,83 @@
+import { PRIVATE_STORAGE_BUCKET } from '$env/static/private';
+import { getFirestore } from 'firebase-admin/firestore';
+import { getStorage } from 'firebase-admin/storage';
+import { auth } from '$lib/server/firebase_server';
+
+export const GET = async ({ params, cookies, request }) => {
+  const db = getFirestore();
+  const { organizationId } = params;
+
+  // session cookie チェック（admin 権限の確認）
+  const session = cookies.get('__session') || '';
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let decodedClaims;
+  try {
+    decodedClaims = await auth.verifySessionCookie(session);
+  } catch (e) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const uid = decodedClaims.uid;
+  const memberDoc = await db.collection(`organizations/${organizationId}/members`).doc(uid).get();
+  if (!memberDoc.exists || !memberDoc.data()?.permission?.admin) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // year パラメータを取得
+  const url = new URL(request.url);
+  const year = parseInt(url.searchParams.get('year'), 10);
+
+  // バリデーション
+  if (isNaN(year) || year < 2024) {
+    return new Response(JSON.stringify({ error: 'Invalid year parameter' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const storage = getStorage();
+    const bucket = storage.bucket(PRIVATE_STORAGE_BUCKET);
+    const filePath = `organizations/${organizationId}/exports/${year}.tsv`;
+    const file = bucket.file(filePath);
+
+    // ファイル存在確認
+    const [exists] = await file.exists();
+    if (!exists) {
+      return new Response(JSON.stringify({ error: 'File not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // 署名付き URL を生成（有効期限: 1時間）
+    const [signedUrl] = await file.getSignedUrl({
+      version: 'v4',
+      action: 'read',
+      expires: Date.now() + 60 * 60 * 1000, // 1時間
+    });
+
+    return new Response(JSON.stringify({ signedUrl }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Signed URL error:', error);
+    return new Response(JSON.stringify({ error: 'Failed to generate signed URL' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/src/routes/api/organizations/[organizationId]/export-get-signed-url/+server.js
+++ b/src/routes/api/organizations/[organizationId]/export-get-signed-url/+server.js
@@ -1,39 +1,8 @@
 import { PRIVATE_STORAGE_BUCKET } from '$env/static/private';
-import { getFirestore } from 'firebase-admin/firestore';
 import { getStorage } from 'firebase-admin/storage';
-import { auth } from '$lib/server/firebase_server';
 
-export const GET = async ({ params, cookies, request }) => {
-  const db = getFirestore();
+export const GET = async ({ params, request }) => {
   const { organizationId } = params;
-
-  // session cookie チェック（admin 権限の確認）
-  const session = cookies.get('__session') || '';
-  if (!session) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-
-  let decodedClaims;
-  try {
-    decodedClaims = await auth.verifySessionCookie(session);
-  } catch (e) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-
-  const uid = decodedClaims.uid;
-  const memberDoc = await db.collection(`organizations/${organizationId}/members`).doc(uid).get();
-  if (!memberDoc.exists || !memberDoc.data()?.permission?.admin) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
 
   // year パラメータを取得
   const url = new URL(request.url);

--- a/src/routes/api/organizations/[organizationId]/export-status/+server.js
+++ b/src/routes/api/organizations/[organizationId]/export-status/+server.js
@@ -1,0 +1,69 @@
+import { PRIVATE_STORAGE_BUCKET } from '$env/static/private';
+import { getFirestore } from 'firebase-admin/firestore';
+import { getStorage } from 'firebase-admin/storage';
+import { auth } from '$lib/server/firebase_server';
+
+export const GET = async ({ params, cookies, request }) => {
+  const db = getFirestore();
+  const { organizationId } = params;
+
+  // session cookie チェック（admin 権限の確認）
+  const session = cookies.get('__session') || '';
+  if (!session) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  let decodedClaims;
+  try {
+    decodedClaims = await auth.verifySessionCookie(session);
+  } catch (e) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const uid = decodedClaims.uid;
+  const memberDoc = await db.collection(`organizations/${organizationId}/members`).doc(uid).get();
+  if (!memberDoc.exists || !memberDoc.data()?.permission?.admin) {
+    return new Response(JSON.stringify({ error: 'Forbidden' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // year パラメータを取得
+  const url = new URL(request.url);
+  const year = parseInt(url.searchParams.get('year'), 10);
+
+  // バリデーション
+  if (isNaN(year) || year < 2024) {
+    return new Response(JSON.stringify({ error: 'Invalid year parameter' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    const storage = getStorage();
+    const bucket = storage.bucket(PRIVATE_STORAGE_BUCKET);
+    const filePath = `organizations/${organizationId}/exports/${year}.tsv`;
+    const file = bucket.file(filePath);
+
+    const [exists] = await file.exists();
+
+    return new Response(JSON.stringify({ exists }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Status check error:', error);
+    return new Response(JSON.stringify({ error: 'Status check failed' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/src/routes/api/organizations/[organizationId]/export-status/+server.js
+++ b/src/routes/api/organizations/[organizationId]/export-status/+server.js
@@ -1,39 +1,8 @@
 import { PRIVATE_STORAGE_BUCKET } from '$env/static/private';
-import { getFirestore } from 'firebase-admin/firestore';
 import { getStorage } from 'firebase-admin/storage';
-import { auth } from '$lib/server/firebase_server';
 
-export const GET = async ({ params, cookies, request }) => {
-  const db = getFirestore();
+export const GET = async ({ params, request }) => {
   const { organizationId } = params;
-
-  // session cookie チェック（admin 権限の確認）
-  const session = cookies.get('__session') || '';
-  if (!session) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-
-  let decodedClaims;
-  try {
-    decodedClaims = await auth.verifySessionCookie(session);
-  } catch (e) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-
-  const uid = decodedClaims.uid;
-  const memberDoc = await db.collection(`organizations/${organizationId}/members`).doc(uid).get();
-  if (!memberDoc.exists || !memberDoc.data()?.permission?.admin) {
-    return new Response(JSON.stringify({ error: 'Forbidden' }), {
-      status: 403,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
 
   // year パラメータを取得
   const url = new URL(request.url);


### PR DESCRIPTION
- export-cards エンドポイントを POST メソッドのみに変更
  * TSV を生成して organizations/{organizationId}/exports/{year}.tsv に保存
  * 1時間有効な署名付きURL を返却

- export-status エンドポイントを新規作成
  * ファイル存在確認用API

- export-get-signed-url エンドポイントを新規作成
  * ダウンロード用署名付きURL取得API

- 管理画面UIを更新
  * 【集計】【ダウンロード】ボタンを分離
  * 年選択時に自動でファイル存在状態をチェック
  * ファイルなし時はダウンロードボタン disabled